### PR TITLE
build-image: add context and container_file inputs

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -2,16 +2,21 @@ name: Build and push container image
 on:
   workflow_call:
     inputs:
+      image:
+        required: true
+        type: string
+      context:
+        required: false
+        type: string
+        default: .
+      container_file:
+        required: false
+        type: string
+        default: Dockerfile
       registry:
         required: false
         type: string
         default: ghcr.io
-      image:
-        required: true
-        type: string
-      container_file:
-        required: true
-        type: string
       debug:
         required: false
         type: boolean
@@ -33,7 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log in to the Container registry
+      - name: Log in to the container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ inputs.registry }}
@@ -46,10 +51,11 @@ jobs:
         with:
           images: ${{ inputs.image }}
 
-      - name: Build and push Docker image
+      - name: Build and push container image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: ${{ inputs.container_file }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.context }}/${{ inputs.container_file }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The context input is optional and defaults to "."
The container_file input is also optional and defaults to Dockerfile

These two parameters provide flexibility for the location and type of image file (ie Dockerfile vs Containerfile)