### PR TITLE
disable concurrency rules for now

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,9 +22,9 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
This appears to be causing jobs to quit when run in parallel for multiple builds. Need to incorporate the job name into the concurrency group most likely. Disabling for now.